### PR TITLE
Add map lookup for keys

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cstring>
 #include <map>
+#include <unordered_map>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -101,7 +102,8 @@ public:
 private:
     UniValue::VType typ;
     std::string val;                       // numbers are stored as C++ strings
-    std::vector<std::string> keys;
+    std::unordered_map<std::string, size_t> keys;
+    std::vector<std::string> key_vector;
     std::vector<UniValue> values;
 
     bool findKey(const std::string& key, size_t& retIdx) const;

--- a/lib/univalue_get.cpp
+++ b/lib/univalue_get.cpp
@@ -48,7 +48,7 @@ const std::vector<std::string>& UniValue::getKeys() const
 {
     if (typ != VOBJ)
         throw std::runtime_error("JSON value is not an object as expected");
-    return keys;
+    return key_vector;
 }
 
 const std::vector<UniValue>& UniValue::getValues() const

--- a/lib/univalue_read.cpp
+++ b/lib/univalue_read.cpp
@@ -431,7 +431,8 @@ bool UniValue::read(const char *raw, size_t size)
         case JTOK_STRING: {
             if (expect(OBJ_NAME)) {
                 UniValue *top = stack.back();
-                top->keys.push_back(tokenVal);
+                top->keys[tokenVal] = top->values.size();
+                top->key_vector.push_back(tokenVal);
                 clearExpect(OBJ_NAME);
                 setExpect(COLON);
             } else {

--- a/lib/univalue_write.cpp
+++ b/lib/univalue_write.cpp
@@ -94,10 +94,10 @@ void UniValue::writeObject(unsigned int prettyIndent, unsigned int indentLevel, 
     if (prettyIndent)
         s += "\n";
 
-    for (unsigned int i = 0; i < keys.size(); i++) {
+    for (unsigned int i = 0; i < key_vector.size(); i++) {
         if (prettyIndent)
             indentStr(prettyIndent, indentLevel, s);
-        s += "\"" + json_escape(keys[i]) + "\":";
+        s += "\"" + json_escape(key_vector[i]) + "\":";
         if (prettyIndent)
             s += " ";
         s += values.at(i).write(prettyIndent, indentLevel + 1);


### PR DESCRIPTION
While this takes a little additional memory (a <string, size_t> map per object), it scales much better when inserting a lot of hash keys, especially when they're unique.

At some point the combination of keys and key vector could be combined into a single data structure, but for now this improvement spends a little memory to save a lot of time.